### PR TITLE
fix for Library is marked as unsaved (*) after accepting changes from the file

### DIFF
--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -910,7 +910,8 @@ public class LibraryTab extends Tab {
                 taskExecutor,
                 dialogService,
                 preferencesService,
-                databaseNotificationPane));
+                databaseNotificationPane,
+                stateManager.activeTabProperty()));
     }
 
     public void copy() {

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -10,6 +10,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.BackgroundTask;
+import org.jabref.gui.util.OptionalObjectProperty;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
@@ -31,18 +32,20 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     private final TaskExecutor taskExecutor;
     private final DialogService dialogService;
     private final PreferencesService preferencesService;
+    private final OptionalObjectProperty<LibraryTab> activeTab;
 
     public DatabaseChangeMonitor(BibDatabaseContext database,
                                  FileUpdateMonitor fileMonitor,
                                  TaskExecutor taskExecutor,
                                  DialogService dialogService,
                                  PreferencesService preferencesService,
-                                 LibraryTab.DatabaseNotification notificationPane) {
+                                 LibraryTab.DatabaseNotification notificationPane, OptionalObjectProperty<LibraryTab> activeTab) {
         this.database = database;
         this.fileMonitor = fileMonitor;
         this.taskExecutor = taskExecutor;
         this.dialogService = dialogService;
         this.preferencesService = preferencesService;
+        this.activeTab = activeTab;
 
         this.listeners = new ArrayList<>();
 
@@ -59,7 +62,7 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
                 Localization.lang("The library has been modified by another program."),
                 List.of(new Action(Localization.lang("Dismiss changes"), event -> notificationPane.hide()),
                         new Action(Localization.lang("Review changes"), event -> {
-                            dialogService.showCustomDialogAndWait(new DatabaseChangesResolverDialog(changes, database, Localization.lang("External Changes Resolver")));
+                            dialogService.showCustomDialogAndWait(new DatabaseChangesResolverDialog(changes, database, Localization.lang("External Changes Resolver"), activeTab));
                             notificationPane.hide();
                         })),
                 Duration.ZERO));

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangesResolverDialog.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangesResolverDialog.java
@@ -15,10 +15,12 @@ import javafx.scene.control.TableView;
 import javafx.scene.layout.BorderPane;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.LibraryTab;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.preview.PreviewViewer;
 import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.util.BaseDialog;
+import org.jabref.gui.util.OptionalObjectProperty;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
@@ -50,6 +52,7 @@ public class DatabaseChangesResolverDialog extends BaseDialog<Boolean> {
 
     private final List<DatabaseChange> changes;
     private final BibDatabaseContext database;
+    private final OptionalObjectProperty<LibraryTab> activeTab;
 
     private ExternalChangesResolverViewModel viewModel;
 
@@ -68,9 +71,10 @@ public class DatabaseChangesResolverDialog extends BaseDialog<Boolean> {
      * @param changes The list of changes
      * @param database The database to apply the changes to
      */
-    public DatabaseChangesResolverDialog(List<DatabaseChange> changes, BibDatabaseContext database, String dialogTitle) {
+    public DatabaseChangesResolverDialog(List<DatabaseChange> changes, BibDatabaseContext database, String dialogTitle, OptionalObjectProperty<LibraryTab> activeTab) {
         this.changes = changes;
         this.database = database;
+        this.activeTab = activeTab;
 
         this.setTitle(dialogTitle);
         ViewLoader.view(this)
@@ -93,7 +97,7 @@ public class DatabaseChangesResolverDialog extends BaseDialog<Boolean> {
         PreviewViewer previewViewer = new PreviewViewer(database, dialogService, preferencesService, stateManager, themeManager, taskExecutor);
         DatabaseChangeDetailsViewFactory databaseChangeDetailsViewFactory = new DatabaseChangeDetailsViewFactory(database, dialogService, stateManager, themeManager, preferencesService, entryTypesManager, previewViewer, taskExecutor);
 
-        viewModel = new ExternalChangesResolverViewModel(changes, undoManager);
+        viewModel = new ExternalChangesResolverViewModel(changes, undoManager, activeTab);
 
         changeName.setCellValueFactory(data -> new SimpleStringProperty(data.getValue().getName()));
         askUserToResolveChangeButton.disableProperty().bind(viewModel.canAskUserToResolveChangeProperty().not());

--- a/src/main/java/org/jabref/gui/collab/ExternalChangesResolverViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/ExternalChangesResolverViewModel.java
@@ -116,5 +116,4 @@ public class ExternalChangesResolverViewModel extends AbstractViewModel {
         ce.end();
         undoManager.addEdit(ce);
     }
-
 }

--- a/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
+++ b/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
@@ -88,7 +88,7 @@ public class BackupUIManager {
                 List<DatabaseChange> changes = DatabaseChangeList.compareAndGetChanges(originalDatabase, backupDatabase, changeResolverFactory);
                 DatabaseChangesResolverDialog reviewBackupDialog = new DatabaseChangesResolverDialog(
                         changes,
-                        originalDatabase, "Review Backup"
+                        originalDatabase, "Review Backup", null
                 );
                 var allChangesResolved = dialogService.showCustomDialogAndWait(reviewBackupDialog);
                 if (allChangesResolved.isEmpty() || !allChangesResolved.get()) {


### PR DESCRIPTION
if external changes are accepted -> asterisk removed and save changes prompt will not pop up when closing tab.
if external changes are denied -> asterisk will be present and save changes prompt will pop up when closing tab.
